### PR TITLE
 Save BOSH environment variables in ~/.env 

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ az network vnet peering create --name opsman-peering --remote-vnet jumpboxVNET -
 ```
 
 Generate the BOSH environment variables: 
-(Put BOSH environment variables in the ./env file so you don't have to run it again if you get disconnected)
+(Put BOSH environment variables in the ~/.env file so you don't have to run it again if you get disconnected)
 ```
 echo "$( \
   om \

--- a/README.md
+++ b/README.md
@@ -489,9 +489,10 @@ az network vnet peering create --name opsman-peering --remote-vnet jumpboxVNET -
 
 ```
 
-Export the BOSH environment variables:
+Generate the BOSH environment variables: 
+(Put BOSH environment variables in the ./env file so you don't have to run it again if you get disconnected)
 ```
-export $( \
+echo "$( \
   om \
     --skip-ssl-validation \
     --target ${PCF_OPSMAN_FQDN} \
@@ -501,7 +502,9 @@ export $( \
       --silent \
       --path /api/v0/deployed/director/credentials/bosh_commandline_credentials | \
         jq --raw-output '.credential' \
-)
+)" >> ~/.env
+
+source ~/.env
 ```
 Copy the root certificate to the jumpbox:
 
@@ -802,7 +805,7 @@ om \
           "instance_type": {
             "id": "automatic"
           },
-          "elb_names": ["'"${WEB_LB}"'"]
+          "elb_names": ['"${WEB_LB}"']
         }'
 
 


### PR DESCRIPTION
Save the BOSH environment variables in  ~/.env file so bosh command works in case user gets disconnected